### PR TITLE
implement gateway api

### DIFF
--- a/bin/opla
+++ b/bin/opla
@@ -26,6 +26,7 @@ const configDefaults = {
   databasePass: "",
   apiEndpoint: "/api",
   authEndpoint: "/auth",
+  gatewayUrl: "https://gateway.opla.ai",
 };
 
 program
@@ -39,6 +40,7 @@ program
   .option("--database-pass [password]", "set the database password", configDefaults.databasePass)
   .option("--api-endpoint [endpoint]", "set the main API endpoint", configDefaults.apiEndpoint)
   .option("--auth-endpoint [endpoint]", "set the auth API endpoint", configDefaults.authEndpoint)
+  .option("--gateway-url [url]", "set the gateway url", configDefaults.gatewayUrl)
   .option("--overwrite", "overwrite existing configuration files", false)
   .action(async (options) => {
     const questions = [
@@ -84,6 +86,12 @@ program
         name: "authEndpoint",
         message: "Auth API endpoint",
         default: options.authEndpoint,
+      },
+      {
+        type: "input",
+        name: "gatewayUrl",
+        message: "Gateway api url",
+        default: options.gatewayUrl,
       },
     ];
 
@@ -139,6 +147,9 @@ program
           },
           botSite: {
             url: "http://127.0.0.1:8085/?b=",
+          },
+          gateway: {
+            url: answers.gatewayUrl,
           },
         },
         auth: {

--- a/src/app.js
+++ b/src/app.js
@@ -9,6 +9,7 @@ import createZoapp from "zoapp-backend";
 import createExtensionsController from "./controllers";
 import buildRoutes from "./routes";
 import plugins from "./plugins";
+import { initGatewayClient } from "./utils/gatewayClient";
 
 class App {
   constructor(config = {}) {
@@ -26,6 +27,7 @@ class App {
     this.zoapp.addPlugins(plugins(this.zoapp.pluginsManager));
 
     buildRoutes(this.zoapp);
+    initGatewayClient(config.global.gateway.url);
   }
 
   async start() {

--- a/src/app.js
+++ b/src/app.js
@@ -9,7 +9,6 @@ import createZoapp from "zoapp-backend";
 import createExtensionsController from "./controllers";
 import buildRoutes from "./routes";
 import plugins from "./plugins";
-import { initGatewayClient } from "./utils/gatewayClient";
 
 class App {
   constructor(config = {}) {
@@ -27,7 +26,6 @@ class App {
     this.zoapp.addPlugins(plugins(this.zoapp.pluginsManager));
 
     buildRoutes(this.zoapp);
-    initGatewayClient(config);
   }
 
   async start() {

--- a/src/app.js
+++ b/src/app.js
@@ -27,7 +27,7 @@ class App {
     this.zoapp.addPlugins(plugins(this.zoapp.pluginsManager));
 
     buildRoutes(this.zoapp);
-    initGatewayClient(config.global.gateway.url);
+    initGatewayClient(config);
   }
 
   async start() {

--- a/src/controllers/admin.js
+++ b/src/controllers/admin.js
@@ -5,16 +5,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 import { Controller } from "zoapp-backend";
-import { getGatewayClient } from "../utils/gatewayClient";
 
 export default class extends Controller {
-  constructor(name, main, className = null) {
+  constructor(name, main, className = null, GatewayClient) {
     super(name, main, className);
-    this.getGatewayClient = getGatewayClient;
+    this.GatewayClient = GatewayClient;
     this.getTemplates = this.getTemplates.bind(this);
   }
 
   async getTemplates() {
-    return this.getGatewayClient().getTemplates();
+    return this.GatewayClient.getTemplates();
   }
 }

--- a/src/controllers/admin.js
+++ b/src/controllers/admin.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2015-present, CWB SAS
+ *
+ * This source code is licensed under the GPL v2.0+ license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import { Controller } from "zoapp-backend";
+import { getGatewayClient } from "../utils/gatewayClient";
+
+export default class extends Controller {
+  constructor(name, main, className = null) {
+    super(name, main, className);
+    this.getGatewayClient = getGatewayClient;
+    this.getTemplates = this.getTemplates.bind(this);
+  }
+
+  async getTemplates() {
+    return this.getGatewayClient().getTemplates();
+  }
+}

--- a/src/controllers/admin.js
+++ b/src/controllers/admin.js
@@ -16,4 +16,8 @@ export default class extends Controller {
   async getTemplates() {
     return this.GatewayClient.getTemplates();
   }
+
+  async getLanguages() {
+    return this.GatewayClient.getLanguages();
+  }
 }

--- a/src/controllers/admin.js
+++ b/src/controllers/admin.js
@@ -7,17 +7,17 @@
 import { Controller } from "zoapp-backend";
 
 export default class extends Controller {
-  constructor(name, main, className = null, GatewayClient) {
+  constructor(name, main, className = null, gatewayClient) {
     super(name, main, className);
-    this.GatewayClient = GatewayClient;
+    this.gatewayClient = gatewayClient;
     this.getTemplates = this.getTemplates.bind(this);
   }
 
   async getTemplates() {
-    return this.GatewayClient.getTemplates();
+    return this.gatewayClient.getTemplates();
   }
 
   async getLanguages() {
-    return this.GatewayClient.getLanguages();
+    return this.gatewayClient.getLanguages();
   }
 }

--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -10,7 +10,7 @@ import SandboxMessengerController from "./sandboxMessenger";
 import MetricsController from "./metrics";
 import AdminController from "./admin";
 import initMiddlewares from "../middlewares";
-import { initGatewayClient } from "../utils/gatewayClient";
+import { initGatewayClient, getGatewayClient } from "../utils/gatewayClient";
 
 class ExtensionsController {
   constructor(zoapp, config) {
@@ -26,12 +26,13 @@ class ExtensionsController {
     );
     this.messenger = new MessengerController("Messenger", this, "messenger");
     this.metrics = new MetricsController("Metrics", this);
-    this.admin = new AdminController("Admin", this);
+
     logger.info("will init");
     if (zoapp.controllers) {
       initMiddlewares(zoapp.controllers.getMiddlewares(), this);
     }
     initGatewayClient(config);
+    this.admin = new AdminController("Admin", this, null, getGatewayClient());
   }
 
   async getAdminParameters(me, isMaster, params) {

--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -8,6 +8,7 @@ import BotsController from "./bots";
 import MessengerController from "./messenger";
 import SandboxMessengerController from "./sandboxMessenger";
 import MetricsController from "./metrics";
+import AdminController from "./admin";
 import initMiddlewares from "../middlewares";
 
 class ExtensionsController {
@@ -24,6 +25,7 @@ class ExtensionsController {
     );
     this.messenger = new MessengerController("Messenger", this, "messenger");
     this.metrics = new MetricsController("Metrics", this);
+    this.admin = new AdminController("Admin", this);
     logger.info("will init");
     if (zoapp.controllers) {
       initMiddlewares(zoapp.controllers.getMiddlewares(), this);
@@ -50,12 +52,14 @@ class ExtensionsController {
     await this.bots.open();
     await this.sandboxMessenger.open();
     await this.messenger.open();
+    await this.admin.open();
   }
 
   async stop() {
     await this.bots.close();
     await this.sandboxMessenger.close();
     await this.messenger.close();
+    await this.admin.close();
   }
 
   getBots() {
@@ -72,6 +76,10 @@ class ExtensionsController {
 
   getMetrics() {
     return this.metrics;
+  }
+
+  getAdmin() {
+    return this.admin;
   }
 }
 

--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -10,6 +10,7 @@ import SandboxMessengerController from "./sandboxMessenger";
 import MetricsController from "./metrics";
 import AdminController from "./admin";
 import initMiddlewares from "../middlewares";
+import { initGatewayClient } from "../utils/gatewayClient";
 
 class ExtensionsController {
   constructor(zoapp, config) {
@@ -30,6 +31,7 @@ class ExtensionsController {
     if (zoapp.controllers) {
       initMiddlewares(zoapp.controllers.getMiddlewares(), this);
     }
+    initGatewayClient(config);
   }
 
   async getAdminParameters(me, isMaster, params) {

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2015-present, CWB SAS
+ *
+ * This source code is licensed under the GPL v2.0+ license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import { CommonRoutes } from "zoapp-backend";
+
+export default class extends CommonRoutes {
+  constructor(zoapp) {
+    super(zoapp.controllers);
+    this.extensions = zoapp.extensions;
+    this.getTemplates = this.getTemplates.bind(this);
+  }
+
+  async getTemplates() {
+    return this.extensions.getAdmin().getTemplates();
+  }
+}

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -11,9 +11,14 @@ export default class extends CommonRoutes {
     super(zoapp.controllers);
     this.extensions = zoapp.extensions;
     this.getTemplates = this.getTemplates.bind(this);
+    this.getLanguages = this.getLanguages.bind(this);
   }
 
   async getTemplates() {
     return this.extensions.getAdmin().getTemplates();
+  }
+
+  async getLanguages() {
+    return this.extensions.getAdmin().getLanguages();
   }
 }

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -19,6 +19,7 @@ export default class extends CommonRoutes {
   }
 
   async getLanguages() {
-    return this.extensions.getAdmin().getLanguages();
+    const languages = await this.extensions.getAdmin().getLanguages();
+    return languages;
   }
 }

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -7,11 +7,13 @@
 import BotsRoutes from "./bots";
 import ConversationsRoutes from "./conversations";
 import MetricsRoutes from "./metrics";
+import AdminRoute from "./admin";
 
 export default (zoapp) => {
   const conversations = new ConversationsRoutes(zoapp);
   const bots = new BotsRoutes(zoapp);
   const metrics = new MetricsRoutes(zoapp);
+  const admin = new AdminRoute(zoapp);
 
   // /conversations routes
   // List all conversations linked to session
@@ -216,4 +218,8 @@ export default (zoapp) => {
   // /metrics routes
   route = zoapp.createRoute("/metrics");
   route.add("GET", "/:botId", ["*", "admin", "master"], metrics.getForBot);
+
+  // /admin routes
+  route = zoapp.createRoute("/admin");
+  route.add("GET", "/templates", ["open"], admin.getTemplates);
 };

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -222,4 +222,5 @@ export default (zoapp) => {
   // /admin routes
   route = zoapp.createRoute("/admin");
   route.add("GET", "/templates", ["open"], admin.getTemplates);
+  route.add("GET", "/languages", ["open"], admin.getLanguages);
 };

--- a/src/utils/gatewayClient.js
+++ b/src/utils/gatewayClient.js
@@ -10,7 +10,7 @@ import merge from "deepmerge";
 
 let client;
 
-class GatewayClient {
+export class GatewayClient {
   constructor(url) {
     this.url = url;
     this.getTemplates = this.getTemplates.bind(this);
@@ -26,7 +26,7 @@ class GatewayClient {
 }
 
 export function getGatewayClient() {
-  if (client === null) {
+  if (!client) {
     throw new Error("client must be initialized before using it");
   }
   return client;

--- a/src/utils/gatewayClient.js
+++ b/src/utils/gatewayClient.js
@@ -6,6 +6,7 @@
  */
 
 import fetch from "zoapp-backend/utils/fetch";
+import merge from "deepmerge";
 
 let client;
 
@@ -25,6 +26,16 @@ export function getGatewayClient() {
   return client;
 }
 
-export function initGatewayClient(url) {
-  client = new GatewayClient(url);
+export function initGatewayClient(config = {}) {
+  const defaultConfig = {
+    global: {
+      gateway: {
+        url: "",
+      },
+    },
+  };
+
+  const cfg = merge(defaultConfig, config);
+
+  client = new GatewayClient(cfg.global.gateway.url);
 }

--- a/src/utils/gatewayClient.js
+++ b/src/utils/gatewayClient.js
@@ -10,19 +10,25 @@ import merge from "deepmerge";
 
 let client;
 
-export default class GatewayClient {
+class GatewayClient {
   constructor(url) {
     this.url = url;
     this.getTemplates = this.getTemplates.bind(this);
   }
 
   async getTemplates() {
-    const templates = await fetch(`${this.url}/templates`);
-    return templates;
+    return fetch(`${this.url}/templates`);
+  }
+
+  async getLanguages() {
+    return fetch(`${this.url}/languages`);
   }
 }
 
 export function getGatewayClient() {
+  if (client === null) {
+    throw new Error("client must be initialized before using it");
+  }
   return client;
 }
 

--- a/src/utils/gatewayClient.js
+++ b/src/utils/gatewayClient.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2015-present, CWB SAS
+ *
+ * This source code is licensed under the GPL v2.0+ license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import fetch from "zoapp-backend/utils/fetch";
+
+let client;
+
+export default class GatewayClient {
+  constructor(url) {
+    this.url = url;
+    this.getTemplates = this.getTemplates.bind(this);
+  }
+
+  async getTemplates() {
+    const templates = await fetch(`${this.url}/templates`);
+    return templates;
+  }
+}
+
+export function getGatewayClient() {
+  return client;
+}
+
+export function initGatewayClient(url) {
+  client = new GatewayClient(url);
+}

--- a/tests/controllers/admin.test.js
+++ b/tests/controllers/admin.test.js
@@ -25,4 +25,23 @@ describe("controller/admin", () => {
       expect(getTemplatesSpy).toHaveBeenCalled();
     });
   });
+
+  describe("getLanguages", () => {
+    it("calls the gateway client", async () => {
+      const getLanguagesSpy = jest.fn();
+      const GatewayClient = {
+        getLanguages: getLanguagesSpy,
+      };
+
+      const controller = new AdminController(
+        "Admin",
+        {},
+        "admin",
+        GatewayClient,
+      );
+      expect(getLanguagesSpy).not.toHaveBeenCalled();
+      await controller.getLanguages();
+      expect(getLanguagesSpy).toHaveBeenCalled();
+    });
+  });
 });

--- a/tests/controllers/admin.test.js
+++ b/tests/controllers/admin.test.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2015-present, CWB SAS
+ *
+ * This source code is licensed under the GPL v2.0+ license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import AdminController from "opla-backend/controllers/admin";
+
+describe("controller/admin", () => {
+  describe("getTemplates", () => {
+    it("calls the gateway client", async () => {
+      const getTemplatesSpy = jest.fn();
+      const GatewayClient = {
+        getTemplates: getTemplatesSpy,
+      };
+
+      const controller = new AdminController(
+        "Admin",
+        {},
+        "admin",
+        GatewayClient,
+      );
+      expect(getTemplatesSpy).not.toHaveBeenCalled();
+      await controller.getTemplates();
+      expect(getTemplatesSpy).toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/routes/admin.test.js
+++ b/tests/routes/admin.test.js
@@ -24,4 +24,22 @@ describe("routes/admin", () => {
       expect(getTemplatesSpy).toHaveBeenCalled();
     });
   });
+
+  describe("getLanguages", () => {
+    it("calls the controller", () => {
+      const getLanguagesSpy = jest.fn();
+      const fakeZoapp = {
+        extensions: {
+          getAdmin: () => ({
+            getLanguages: getLanguagesSpy,
+          }),
+        },
+      };
+
+      const routes = new AdminRoutes(fakeZoapp);
+      expect(getLanguagesSpy).not.toHaveBeenCalled();
+      routes.getLanguages();
+      expect(getLanguagesSpy).toHaveBeenCalled();
+    });
+  });
 });

--- a/tests/routes/admin.test.js
+++ b/tests/routes/admin.test.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2015-present, CWB SAS
+ *
+ * This source code is licensed under the GPL v2.0+ license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import AdminRoutes from "opla-backend/routes/admin";
+
+describe("routes/admin", () => {
+  describe("getTemplates", () => {
+    it("calls the controller", () => {
+      const getTemplatesSpy = jest.fn();
+      const fakeZoapp = {
+        extensions: {
+          getAdmin: () => ({
+            getTemplates: getTemplatesSpy,
+          }),
+        },
+      };
+
+      const routes = new AdminRoutes(fakeZoapp);
+      expect(getTemplatesSpy).not.toHaveBeenCalled();
+      routes.getTemplates();
+      expect(getTemplatesSpy).toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/utils/gatewayClient.test.js
+++ b/tests/utils/gatewayClient.test.js
@@ -4,11 +4,12 @@
  * This source code is licensed under the GPL v2.0+ license found in the
  * LICENSE file in the root directory of this source tree.
  */
+import fetch from "zoapp-backend/utils/fetch";
 import {
   getGatewayClient,
   initGatewayClient,
   GatewayClient,
-} from "../../src/utils/gatewayClient";
+} from "opla-backend/utils/gatewayClient";
 
 describe("getGatewayClient", () => {
   it("throws an error if the gateway is not initialized", () => {
@@ -21,5 +22,28 @@ describe("getGatewayClient", () => {
     initGatewayClient();
     const client = getGatewayClient();
     expect(client).toBeInstanceOf(GatewayClient);
+  });
+});
+
+jest.mock("zoapp-backend/utils/fetch");
+describe("GatewayClient", () => {
+  beforeEach(() => {
+    fetch.mockClear();
+  });
+
+  describe("getTemplates", () => {
+    it("should call /templates endpoint", () => {
+      const client = new GatewayClient("https://gateway.opla.ai");
+      client.getTemplates();
+      expect(fetch).toHaveBeenCalledWith("https://gateway.opla.ai/templates");
+    });
+  });
+
+  describe("getLanguages", () => {
+    it("should call /languages endpoint", () => {
+      const client = new GatewayClient("https://gateway.opla.ai");
+      client.getLanguages();
+      expect(fetch).toHaveBeenCalledWith("https://gateway.opla.ai/languages");
+    });
   });
 });

--- a/tests/utils/gatewayClient.test.js
+++ b/tests/utils/gatewayClient.test.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2015-present, CWB SAS
+ *
+ * This source code is licensed under the GPL v2.0+ license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import {
+  getGatewayClient,
+  initGatewayClient,
+  GatewayClient,
+} from "../../src/utils/gatewayClient";
+
+describe("getGatewayClient", () => {
+  it("throws an error if the gateway is not initialized", () => {
+    expect(() => {
+      getGatewayClient();
+    }).toThrowError("client must be initialized before using it");
+  });
+
+  it("returns a valid Gateway instance once initialized", () => {
+    initGatewayClient();
+    const client = getGatewayClient();
+    expect(client).toBeInstanceOf(GatewayClient);
+  });
+});


### PR DESCRIPTION
this repo will act like a proxy between `opla/front` and the gateway api.
It will provides two new endpoints : 
- `GET /admin/templates`
- `GET /admin/languages`

## TODO

- [x] configure gateway url
- [x]  create a client to getch gateway api
- [x] create routes that match routes describe above